### PR TITLE
add frontend of github login 增加GitHub授权登录的前端

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .config/
 config.js
 temp.md
+client/.env.development

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1985,6 +1985,43 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "axios": "^0.19.0",
     "core-js": "^2.6.5",
     "register-service-worker": "^1.6.2",
     "vue": "^2.6.10",

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -5,6 +5,8 @@ import Home from "./views/Home.vue";
 Vue.use(Router);
 
 export default new Router({
+  mode: 'history',
+  base: '',
   routes: [
     {
       path: "/",
@@ -19,6 +21,11 @@ export default new Router({
       // which is lazy-loaded when the route is visited.
       component: () =>
         import(/* webpackChunkName: "about" */ "./views/About.vue")
+    },
+    {
+      path: "/login/github",
+      name: "GithubLogin",
+      component: () => import("./views/GithubLogin.vue")
     }
   ]
 });

--- a/client/src/views/GithubLogin.vue
+++ b/client/src/views/GithubLogin.vue
@@ -1,0 +1,35 @@
+// 引导重定向， 还有拿到code之后返回， 都是到这个页面上去
+
+<template>
+  <p>redirecting....</p>
+</template>
+
+<script>
+
+import axios from 'axios'
+
+export default {
+  name: 'GithubLogin',
+  computed: {},
+  created() {
+    const { path, query } = this.$route
+    const { code, from } = query
+    const clientID = process.env.VUE_APP_GITHUB_CLIENT_ID
+    console.log(clientID)
+    const scope = 'read:public_repo,read:user'
+    // 没有code的话， 要引导用户去GitHub的页面进行登录和授权操作
+    if (!code) {
+      window.location = `https://github.com/login/oauth/authorize?client_id=${clientID}&scope=${scope}`
+    // 有code， 证明用户已经做了授权操作， 需要提交后端后端验证这个code的正确性
+    } else {
+      console.log(code)
+      axios
+        .get(process.env.VUE_APP_BACKEND + `/login/verify?code=${code}`)
+        .then(response => {
+          console.log(response)
+        })
+    }
+  }
+}
+
+</script>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -22,6 +22,15 @@ export default {
   name: "home",
   components: {
     HelloWorld
+  },
+  methods: {
+    // 点击时候触发， 重定向到登陆页面
+    async walletLogin(type) {
+      if (type === 'GitHub') {
+        this.$router.push({ name: 'GithubLogin' })
+        return
+      }
+    }
   }
 };
 </script>


### PR DESCRIPTION
用户点击GitHub登录之后， 先跳到GitHub的网页去登录授权， 再带着code返回， 此两者公用一个路径， 还需要建设后端以验证这个code的正确性， 证确则是授权成功。